### PR TITLE
Fix React undefined error by enabling Vite React plugin

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,8 +1,10 @@
 // vite.config.js
 import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  plugins: [react()],
   css: {
-    postcss: './postcss.config.cjs', 
+    postcss: './postcss.config.cjs',
   },
 });


### PR DESCRIPTION
## Summary
- configure Vite to use `@vitejs/plugin-react` so JSX compiles with automatic runtime

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a4a66890cc8330b994cd7b17e71844